### PR TITLE
Fixed multiple issues with semantic types

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -55,6 +55,7 @@ import { PrimitiveSchemaComponent } from './primitive-schema/primitive-schema.co
 import { ContentInterceptor } from './services/interceptors/content-interceptor';
 import { ModelValidationComponent } from './model-validation/model-validation.component';
 import { ImportModelComponent } from './import-model/import-model.component';
+import { FilterPipe } from './filters/filter.pipe';
 
 @NgModule({
   declarations: [
@@ -86,7 +87,8 @@ import { ImportModelComponent } from './import-model/import-model.component';
     MapValueComponent,
     PrimitiveSchemaComponent,
     ModelValidationComponent,
-    ImportModelComponent
+    ImportModelComponent,
+    FilterPipe
   ],
   imports: [
     BrowserModule,

--- a/src/app/filters/filter.pipe.ts
+++ b/src/app/filters/filter.pipe.ts
@@ -1,0 +1,14 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'filter'
+})
+export class FilterPipe implements PipeTransform {
+
+  transform(items: any[], callback: (item: any) => boolean): any {
+    if (!items || !callback) {
+      return items;
+    }
+    return items.filter(item => callback(item));
+  }
+}

--- a/src/app/formControls/PropertyCapabilityFormControl.ts
+++ b/src/app/formControls/PropertyCapabilityFormControl.ts
@@ -23,7 +23,6 @@ export class PropertyCapabilityFormControl extends AbstractCapabilityFormControl
       // Property specific
       name: [this.model.name],
       schema: [],
-      semanticType: [this.model.semanticType],
       unit: [this.model.unit],
       writable: [this.model.writable]
     });

--- a/src/app/formControls/TelemetryCapabilityFormControl.ts
+++ b/src/app/formControls/TelemetryCapabilityFormControl.ts
@@ -23,7 +23,6 @@ export class TelemetryCapabilityFormControl extends AbstractCapabilityFormContro
       // Telemetry specific
       name: [this.model.name],
       schema: [],
-      semanticType: [this.model.semanticType],
       unit: [this.model.unit]
     });
 

--- a/src/app/formControls/TelemetryCapabilityFormControl.ts
+++ b/src/app/formControls/TelemetryCapabilityFormControl.ts
@@ -18,11 +18,11 @@ export class TelemetryCapabilityFormControl extends AbstractCapabilityFormContro
       id: [this.model.id, [this._validationService.validDtmi()]],
       type: [this.model.type],
       displayName: [this.model.displayName],
-      name: [this.model.name],
       comment: [this.model.comment],
       description: [this.model.description],
       // Telemetry specific
-      schema: [this.model.schema],
+      name: [this.model.name],
+      schema: [],
       semanticType: [this.model.semanticType],
       unit: [this.model.unit]
     });

--- a/src/app/map-schema/map-schema.component.ts
+++ b/src/app/map-schema/map-schema.component.ts
@@ -74,12 +74,6 @@ export class MapSchemaComponent implements OnInit {
       if (formControl === undefined) return;
       this.valueSchemaFormControl = formControl;
     }
-
-    // if ($event.value instanceof AbstractCapabilityFormControl) return;
-    // let key = $event.value.toLowerCase();
-    // let formControl = this.schemaService.createForm("MapValue", key) as MapValueFormControl;
-    // if (formControl === undefined) return;
-    // this.valueSchemaFormControl = formControl;
   }
 
   public openKeyEditor(): void {

--- a/src/app/models/PropertyCapabilityModel.ts
+++ b/src/app/models/PropertyCapabilityModel.ts
@@ -12,8 +12,6 @@ export class PropertyCapabilityModel extends AbstractCapabilityModel {
   @jsonMember 
   public schema!: string | AbstractCapabilityModel;
 
-  public semanticType!: string;
-
   @jsonMember 
   public unit!: string;
 

--- a/src/app/models/TelemetryCapabilityModel.ts
+++ b/src/app/models/TelemetryCapabilityModel.ts
@@ -12,8 +12,6 @@ export class TelemetryCapabilityModel extends AbstractCapabilityModel {
   @jsonMember 
   public schema!: string | AbstractCapabilityModel;
 
-  public semanticType!: string;
-
   @jsonMember 
   public unit!: string;
 

--- a/src/app/models/TelemetryCapabilityModel.ts
+++ b/src/app/models/TelemetryCapabilityModel.ts
@@ -10,9 +10,8 @@ export class TelemetryCapabilityModel extends AbstractCapabilityModel {
   public  name!: string;
 
   @jsonMember 
-  public schema!: AbstractCapabilityModel;
+  public schema!: string | AbstractCapabilityModel;
 
-  // No SerDes
   public semanticType!: string;
 
   @jsonMember 

--- a/src/app/property/property.component.html
+++ b/src/app/property/property.component.html
@@ -29,8 +29,8 @@
 
     <mat-form-field color="accent">
         <mat-label attr.for="property_schema_{{formIndex}}">Schema</mat-label>
-        <mat-select [compareWith]="schemaService.compareSchemas" matNativeControl id="property_schema_{{formIndex}}" 
-                    (selectionChange)="changeSchema($event)" #schema>
+        <mat-select [compareWith]="compareSchemas" matNativeControl id="property_schema_{{formIndex}}" 
+                    (selectionChange)="changeSchema($event)" [formControl]="schemaDropDownControl" #schema>
           <mat-option *ngFor="let schemaType of schemaTypes" [value]="schemaType">{{schemaType}}</mat-option>
         </mat-select>
     </mat-form-field>
@@ -47,7 +47,7 @@
         <mat-label attr.for="property_semanticType_{{formIndex}}">Semantic Type</mat-label>
         <mat-select matNativeControl id="property_semanticType_{{formIndex}}" formControlName="semanticType"
                     (selectionChange)="changeSemanticType($event)">
-            <mat-option *ngFor="let semanticType of editorService.semanticTypes" [value]="semanticType"> {{ semanticType }} </mat-option>
+            <mat-option *ngFor="let semanticType of semanticTypes" [value]="semanticType">{{semanticType}}</mat-option>
         </mat-select>
     </mat-form-field>
     <span class="formSpacer"></span>

--- a/src/app/property/property.component.html
+++ b/src/app/property/property.component.html
@@ -31,7 +31,7 @@
         <mat-label attr.for="property_schema_{{formIndex}}">Schema</mat-label>
         <mat-select [compareWith]="compareSchemas" matNativeControl id="property_schema_{{formIndex}}" 
                     (selectionChange)="changeSchema($event)" [formControl]="schemaDropDownControl" #schema>
-          <mat-option *ngFor="let schemaType of schemaTypes" [value]="schemaType">{{schemaType}}</mat-option>
+          <mat-option *ngFor="let schemaType of getSchemaTypes().filter(validSchemaTypes)" [value]="schemaType">{{schemaType}}</mat-option>
         </mat-select>
     </mat-form-field>
     <span class="formSpacer"></span>
@@ -45,9 +45,9 @@
 
     <mat-form-field color="accent">
         <mat-label attr.for="property_semanticType_{{formIndex}}">Semantic Type</mat-label>
-        <mat-select matNativeControl id="property_semanticType_{{formIndex}}" formControlName="semanticType"
-                    (selectionChange)="changeSemanticType($event)">
-            <mat-option *ngFor="let semanticType of semanticTypes" [value]="semanticType">{{semanticType}}</mat-option>
+        <mat-select matNativeControl id="property_semanticType_{{formIndex}}"
+                    (selectionChange)="changeSemanticType($event)" [formControl]="semanticTypeDropDownControl" #semanticType>
+            <mat-option *ngFor="let semanticType of getSemanticTypes()" [value]="semanticType">{{semanticType}}</mat-option>
         </mat-select>
     </mat-form-field>
     <span class="formSpacer"></span>

--- a/src/app/property/property.component.ts
+++ b/src/app/property/property.component.ts
@@ -8,6 +8,7 @@ import { PropertyCapabilityFormControl } from '../formControls/PropertyCapabilit
 import { AbstractCapabilityFormControl } from '../formControls/AbstractCapabilityFormControl';
 import { AbstractCapabilityModel } from '../models/AbstractCapabilityModel';
 import { SchemaTypeEnum } from '../models/SchemaTypeEnum';
+import { FormControl } from '@angular/forms';
 
 @Component({
   selector: 'property-definition',
@@ -18,20 +19,23 @@ export class PropertyComponent implements OnInit {
   @Input() public formIndex!: [number, number];
   @Input() public property!: PropertyCapabilityFormControl;
   @Input() public panelOpenState!: boolean;
-  public editorService: EditorService;
-  public schemaService: SchemaService;
+  private _editorService: EditorService;
+  private _schemaService: SchemaService;
   public dialog: MatDialog;
-  public schemaTypes: Array<string>;
-  public schemaFormControl!: AbstractCapabilityFormControl<AbstractCapabilityModel>;
+  public schemaTypes!: Array<string>;
+  public semanticTypes!: Array<string>;
+  public schemaFormControl!: AbstractCapabilityFormControl<AbstractCapabilityModel> | undefined;
+  public schemaDropDownControl: FormControl = new FormControl([]);
 
   constructor(editorService: EditorService, schemaService: SchemaService, dialog: MatDialog) {
-    this.editorService = editorService;
-    this.schemaService = schemaService;
+    this._editorService = editorService;
+    this._schemaService = schemaService;
     this.dialog = dialog;
-    this.schemaTypes = this.getSchemaTypes();
   }
 
   public ngOnInit(): void {
+    this.schemaTypes = this.getSchemaTypes();
+    this.semanticTypes = this.getSemanticTypes();
     this.property.subscribeModelToForm();
     this.syncHeaderFields();
   }
@@ -52,21 +56,35 @@ export class PropertyComponent implements OnInit {
   private getSchemaTypes(): Array<string> {
     let schemaTypes = new Array<string>();
 
-    this.schemaService.schemaFactory.formRegistry.get("Primitive")?.forEach((value, key) => {
+    this._schemaService.schemaFactory.formRegistry.get("Primitive")?.forEach((value, key) => {
       schemaTypes.push(key);
     });
 
-    this.schemaService.schemaFactory.formRegistry.get("Complex")?.forEach((value, key) => {
+    this._schemaService.schemaFactory.formRegistry.get("Complex")?.forEach((value, key) => {
       schemaTypes.push(key);
     });
 
     return schemaTypes;
   }
 
+  private getSemanticTypes(): Array<string> {
+    return this._editorService.getSemanticTypes();
+  }
+
   public getUnits(): string[] | undefined {
     let unit = this.property.form.get("semanticType")?.value;
-    let units = this.editorService.getUnits().get(unit);
+    let units = this._editorService.getUnits().get(unit);
     return units;
+  }
+
+  // TODO: Passing validSchemaTypes to the FilterPipe doesn't get re-evaluated on changes
+  //       Ideally, we'd use the FilterPipe in the component view to filter the array values.
+  //       However, the filter function only executes once and is not ever re-evaluated if the view or form changes. 
+  public validSchemaTypes = (schemaType: string): boolean => {
+    if (this.property.form.get("semanticType")?.value)
+      return ["double", "float", "integer", "long"].indexOf(schemaType.toLowerCase()) > -1;
+    else
+      return true;
   }
 
   public changeSemanticType($event: MatSelectChange): void {
@@ -77,30 +95,48 @@ export class PropertyComponent implements OnInit {
       type?.setValue(semanticType);
       let unit = this.property.form.get("unit");
       unit?.setValue(undefined);
+      this.schemaTypes = this.getSchemaTypes();
     } else {
       let semanticType = new SemanticTypeArray("Property", $event.value);
       type?.setValue(semanticType);
+
+      let schema = this.property.form.get("schema")?.value;
+      if (["double", "float", "integer", "long"].indexOf(schema.toLowerCase()) === -1) {
+        this.property.form.get("schema")?.setValue(undefined);
+        this.schemaDropDownControl.setValue(undefined);
+        this.schemaFormControl = undefined;
+      }
+
+      this.schemaTypes = this.getSchemaTypes().filter(this.validSchemaTypes);
     }
   }
 
   public isComplex(schema: string): boolean {
-    return this.schemaService.getSchemaType(schema) == SchemaTypeEnum.Complex;
+    if (typeof schema == 'string')
+      return this._schemaService.getSchemaType(schema) == SchemaTypeEnum.Complex;
+
+    return false;
+  }
+
+  public compareSchemas = (model1: AbstractCapabilityModel, model2: AbstractCapabilityModel): boolean => {
+    return this._schemaService.compareSchemas(model1, model2)
   }
 
   public changeSchema($event: MatSelectChange): void {
     if ($event.value instanceof AbstractCapabilityFormControl) return;
     let key = $event.value.toLowerCase();
-    let schemaType = this.schemaService.getSchemaType(key);
+    let schemaType = this._schemaService.getSchemaType(key);
     this.property.form.get("schema")?.setValue(key);
 
     if (schemaType == SchemaTypeEnum.Complex) {
-      let formControl = this.schemaService.createForm(SchemaTypeEnum[schemaType], key);
+      let formControl = this._schemaService.createForm(SchemaTypeEnum[schemaType], key);
       if (formControl === undefined) return;
       this.schemaFormControl = formControl;
     }
   }
 
   public openSchemaEditor(): void {
-    this.schemaService.openSchemaEditor(this.property.form, this.schemaFormControl)
+    if(this.schemaFormControl)
+      this._schemaService.openSchemaEditor(this.property.form, this.schemaFormControl)
   }
 }

--- a/src/app/telemetry/telemetry.component.html
+++ b/src/app/telemetry/telemetry.component.html
@@ -30,7 +30,7 @@
         <mat-label attr.for="telemetry_schema_{{formIndex}}">Schema</mat-label>
         <mat-select [compareWith]="compareSchemas" matNativeControl id="telemetry_schema_{{formIndex}}" 
                     (selectionChange)="changeSchema($event)" [formControl]="schemaDropDownControl" #schema>
-          <mat-option *ngFor="let schemaType of schemaTypes" [value]="schemaType">{{schemaType}}</mat-option>
+          <mat-option *ngFor="let schemaType of getSchemaTypes().filter(validSchemaTypes)" [value]="schemaType">{{schemaType}}</mat-option>
         </mat-select>
     </mat-form-field>
     <span class="formSpacer"></span>
@@ -44,9 +44,9 @@
 
     <mat-form-field color="accent">
         <mat-label attr.for="telemetry_semanticType_{{formIndex}}">Semantic Type</mat-label>
-        <mat-select matNativeControl id="telemetry_semanticType_{{formIndex}}" formControlName="semanticType"
-                    (selectionChange)="changeSemanticType($event)">
-            <mat-option *ngFor="let semanticType of semanticTypes" [value]="semanticType">{{semanticType}}</mat-option>
+        <mat-select matNativeControl id="telemetry_semanticType_{{formIndex}}"
+                    (selectionChange)="changeSemanticType($event)" [formControl]="semanticTypeDropDownControl">
+            <mat-option *ngFor="let semanticType of getSemanticTypes()" [value]="semanticType">{{semanticType}}</mat-option>
         </mat-select>
     </mat-form-field>
     <span class="formSpacer"></span>

--- a/src/app/telemetry/telemetry.component.html
+++ b/src/app/telemetry/telemetry.component.html
@@ -28,8 +28,8 @@
 
     <mat-form-field color="accent">
         <mat-label attr.for="telemetry_schema_{{formIndex}}">Schema</mat-label>
-        <mat-select [compareWith]="schemaService.compareSchemas" matNativeControl id="telemetry_schema_{{formIndex}}" 
-                    (selectionChange)="changeSchema($event)" #schema>
+        <mat-select [compareWith]="compareSchemas" matNativeControl id="telemetry_schema_{{formIndex}}" 
+                    (selectionChange)="changeSchema($event)" [formControl]="schemaDropDownControl" #schema>
           <mat-option *ngFor="let schemaType of schemaTypes" [value]="schemaType">{{schemaType}}</mat-option>
         </mat-select>
     </mat-form-field>
@@ -46,7 +46,7 @@
         <mat-label attr.for="telemetry_semanticType_{{formIndex}}">Semantic Type</mat-label>
         <mat-select matNativeControl id="telemetry_semanticType_{{formIndex}}" formControlName="semanticType"
                     (selectionChange)="changeSemanticType($event)">
-            <mat-option *ngFor="let semanticType of editorService.semanticTypes" [value]="semanticType"> {{ semanticType }} </mat-option>
+            <mat-option *ngFor="let semanticType of semanticTypes" [value]="semanticType">{{semanticType}}</mat-option>
         </mat-select>
     </mat-form-field>
     <span class="formSpacer"></span>

--- a/src/app/telemetry/telemetry.component.ts
+++ b/src/app/telemetry/telemetry.component.ts
@@ -8,6 +8,7 @@ import { TelemetryCapabilityFormControl } from '../formControls/TelemetryCapabil
 import { AbstractCapabilityFormControl } from '../formControls/AbstractCapabilityFormControl';
 import { AbstractCapabilityModel } from '../models/AbstractCapabilityModel';
 import { SchemaTypeEnum } from '../models/SchemaTypeEnum';
+import { FormControl } from '@angular/forms';
 
 @Component({
   selector: 'telemetry-definition',
@@ -18,89 +19,121 @@ export class TelemetryComponent implements OnInit {
   @Input() public formIndex!: [number, number];
   @Input() public telemetry!: TelemetryCapabilityFormControl;
   @Input() public panelOpenState!: boolean;
-  public editorService: EditorService;
-  public schemaService: SchemaService;
+  private _editorService: EditorService;
+  private _schemaService: SchemaService;
   public dialog: MatDialog;
-  public schemaTypes: Array<string>;
-  public schemaFormControl!: AbstractCapabilityFormControl<AbstractCapabilityModel>;
-  
-  constructor(editorService: EditorService, schemaService: SchemaService, dialog: MatDialog) { 
-    this.editorService = editorService;
-    this.schemaService = schemaService;
+  public schemaTypes!: Array<string>;
+  public semanticTypes!: Array<string>;
+  public schemaFormControl!: AbstractCapabilityFormControl<AbstractCapabilityModel> | undefined;
+  public schemaDropDownControl: FormControl = new FormControl([]);
+
+  constructor(editorService: EditorService, schemaService: SchemaService, dialog: MatDialog) {
+    this._editorService = editorService;
+    this._schemaService = schemaService;
     this.dialog = dialog;
-    this.schemaTypes = this.getSchemaTypes();
   }
 
-  public ngOnInit(): void {  
+  public ngOnInit(): void {
+    this.schemaTypes = this.getSchemaTypes();
+    this.semanticTypes = this.getSemanticTypes();
     this.telemetry.subscribeModelToForm();
-    this.syncHeaderFields();    
+    this.syncHeaderFields();
   }
 
   public syncHeaderFields() {
     const id = this.telemetry.form.get("id");
     const name = this.telemetry.form.get("name");
 
-    id?.valueChanges.subscribe(value => {      
+    id?.valueChanges.subscribe(value => {
       id.setValue(value, { emitEvent: false })
     });
 
     name?.valueChanges.subscribe(value => {
       name.setValue(value, { emitEvent: false })
-    });    
+    });
   }
 
   private getSchemaTypes(): Array<string> {
     let schemaTypes = new Array<string>();
-    
-    this.schemaService.schemaFactory.formRegistry.get("Primitive")?.forEach((value, key) => {
+
+    this._schemaService.schemaFactory.formRegistry.get("Primitive")?.forEach((value, key) => {
       schemaTypes.push(key);
     });
 
-    this.schemaService.schemaFactory.formRegistry.get("Complex")?.forEach((value, key) => {
+    this._schemaService.schemaFactory.formRegistry.get("Complex")?.forEach((value, key) => {
       schemaTypes.push(key);
     });
 
     return schemaTypes;
   }
 
+  private getSemanticTypes(): Array<string> {
+    return this._editorService.getSemanticTypes();
+  }
+
   public getUnits(): string[] | undefined {
     let unit = this.telemetry.form.get("semanticType")?.value;
-    let units = this.editorService.getUnits().get(unit);
+    let units = this._editorService.getUnits().get(unit);
     return units;
+  }
+
+  public validSchemaTypes = (schemaType: string): boolean => {
+    if (this.telemetry.form.get("semanticType")?.value)
+      return ["double", "float", "integer", "long"].indexOf(schemaType.toLowerCase()) > -1;
+    else
+      return true;
   }
 
   public changeSemanticType($event: MatSelectChange): void {
     let type = this.telemetry.form.get("type");
 
-    if(["", null, undefined].indexOf($event.value) > -1) {
+    if (["", null, undefined].indexOf($event.value) > -1) {
       let semanticType = new SemanticTypeArray("Telemetry");
-      type?.setValue(semanticType);      
+      type?.setValue(semanticType);
       let unit = this.telemetry.form.get("unit");
       unit?.setValue(undefined);
+      this.schemaTypes = this.getSchemaTypes();
     } else {
       let semanticType = new SemanticTypeArray("Telemetry", $event.value);
       type?.setValue(semanticType);
+
+      let schema = this.telemetry.form.get("schema")?.value;
+      if (["double", "float", "integer", "long"].indexOf(schema.toLowerCase()) === -1) {
+        this.telemetry.form.get("schema")?.setValue(undefined);
+        this.schemaDropDownControl.setValue(undefined);
+        this.schemaFormControl = undefined;
+      }
+
+      this.schemaTypes = this.getSchemaTypes().filter(this.validSchemaTypes);
     }
   }
 
   public isComplex(schema: string): boolean {
-    return this.schemaService.getSchemaType(schema) == SchemaTypeEnum.Complex;
+    if (typeof schema == 'string')
+      return this._schemaService.getSchemaType(schema) == SchemaTypeEnum.Complex;
+
+    return false;
+  }
+
+  public compareSchemas = (model1: AbstractCapabilityModel, model2: AbstractCapabilityModel): boolean => {
+    return this._schemaService.compareSchemas(model1, model2)
   }
 
   public changeSchema($event: MatSelectChange): void {
-    if($event.value instanceof AbstractCapabilityFormControl) return;
+    if ($event.value instanceof AbstractCapabilityFormControl) return;
     let key = $event.value.toLowerCase();
-    let schemaType = this.schemaService.getSchemaType(key);
+    let schemaType = this._schemaService.getSchemaType(key);
     this.telemetry.form.get("schema")?.setValue(key);
 
-    if(schemaType == SchemaTypeEnum.Complex) {
-      let formControl = this.schemaService.createForm(SchemaTypeEnum[schemaType], key);
-      if(formControl === undefined) return;
+    if (schemaType == SchemaTypeEnum.Complex) {
+      let formControl = this._schemaService.createForm(SchemaTypeEnum[schemaType], key);
+      if (formControl === undefined) return;
       this.schemaFormControl = formControl;
     }
   }
 
   public openSchemaEditor(): void {
-    this.schemaService.openSchemaEditor(this.telemetry.form, this.schemaFormControl)
+    if (this.schemaFormControl)
+      this._schemaService.openSchemaEditor(this.telemetry.form, this.schemaFormControl)
   }
 }


### PR DESCRIPTION
The `semanticType` property is no longer on the `ICapabilityModel` or `CapabilityFormControl` classes. This prevents it from being rendered in the JSON-LD output. Instead, a distinct `FormControl` instance was added to the Property and Telemetry components.

Also added in this update is more robust business logic for enforcing correct schemas (number types) when selecting a semantic type. Only valid schema types are selectable when a semantic type is selected. If an invalid schema is selected already it is cleared out.